### PR TITLE
fix: initial fixes

### DIFF
--- a/mac-os.sh
+++ b/mac-os.sh
@@ -7,10 +7,8 @@
 # Usage: curl -fsSL <endpoint> | sudo bash -s -- [options]
 # Or: ./mac-os.sh [options]
 # Options:
-#   -h, --help              Show help message
-#   -q, --quick             Minimal setup (keychain verify; no certifi bundle update)
-#   -d, --deep              Full setup (includes certifi bundle update)
-#   -r, --revert            Revert Netskope certificates and clean up configuration (requires sudo)
+#   -h, --help              Show this help message
+#   -r, --revert            Revert Netskope certificates and clean up configuration
 #
 
 set -uo pipefail
@@ -218,8 +216,6 @@ if [[ "$*" == *"--help"* ]] || [[ "$*" == *"-h"* ]]; then
         echo ""
         echo -e "${BOLD}${GREEN}OPTIONS:${NC}"
         echo -e "  ${YELLOW}-h, --help${NC}              Show this help message"
-        echo -e "  ${YELLOW}-q, --quick${NC}            Minimal setup (no certifi changes)"
-        echo -e "  ${YELLOW}-d, --deep${NC}             Full setup (includes certifi changes)"
         echo -e "  ${YELLOW}-r, --revert${NC}           Revert Netskope certificates and clean up configuration"
         echo ""
         echo -e "${BOLD}${GREEN}DESCRIPTION:${NC}"
@@ -229,9 +225,7 @@ if [[ "$*" == *"--help"* ]] || [[ "$*" == *"-h"* ]]; then
         echo -e "  Environment variables are automatically configured in your shell."
         echo ""
         echo -e "${BOLD}${GREEN}EXAMPLES:${NC}"
-        echo -e "  ${DIM}curl -fsSL <endpoint> | sudo bash -s -- --all${NC}"
-        echo -e "  ${DIM}curl -fsSL <endpoint> | sudo bash -s -- --bundle${NC}"  
-        echo -e "  ${DIM}curl -fsSL <endpoint> | sudo bash -s -- --verify${NC}"
+        echo -e "  ${DIM}curl -fsSL <endpoint> | sudo bash -s --${NC}"
         echo -e "  ${DIM}curl -fsSL <endpoint> | sudo bash -s -- --revert${NC}"
         echo ""
     }


### PR DESCRIPTION
This pull request simplifies the `mac-os.sh` script by removing unused options and improving reliability in certain operations. The most important changes are grouped below:

**Command-line options and help output:**

* Removed the `--quick` and `--deep` options from both the script usage comments and the help output, leaving only `--help` and `--revert` as documented options. This reduces confusion and clarifies the available functionality. [[1]](diffhunk://#diff-74bdf92fad704258fe2263a16696a1b096d13dcc8fcaa1cd62c119df89c21793L10-R11) [[2]](diffhunk://#diff-74bdf92fad704258fe2263a16696a1b096d13dcc8fcaa1cd62c119df89c21793L221-L222)
* Updated the help example commands to reflect the removal of the old options, now showing only the default and `--revert` usage.

**Script robustness and reliability:**

* Added logic to drain stdin if the script is exited early when invoked via a pipe (e.g., `curl | bash`). This prevents a `curl` error (error 23) by consuming the remainder of the piped input, avoiding a SIGPIPE.
* Improved the method for counting certificate entries by switching from `grep -c .` to a combination of `sed`, `wc -l`, and `tr` to count non-empty lines. This avoids non-zero exit codes under `pipefail` and improves reliability. [[1]](diffhunk://#diff-74bdf92fad704258fe2263a16696a1b096d13dcc8fcaa1cd62c119df89c21793L1520-R1520) [[2]](diffhunk://#diff-74bdf92fad704258fe2263a16696a1b096d13dcc8fcaa1cd62c119df89c21793L1541-R1542)